### PR TITLE
Update alpine-linux-os.md

### DIFF
--- a/docs/stake-pool-guides/alpine-linux-os.md
+++ b/docs/stake-pool-guides/alpine-linux-os.md
@@ -27,13 +27,13 @@ git fetch --recurse-submodules --tags --all
 git tag
 ```
 
-3\) Replace `<tag>` in this step with the latest tag such as `v1.5.0`.
+3\) Replace `<tag>` in this step with the latest tag such as `v1.6.0`.
 
 ```
 git checkout tags/<tag>
 ```
 
-## Upgrading to Alpine v3.15 from Alpine v3.14:
+## Upgrading to Alpine v3.16 from Alpine v3.15:
 
 1\) Update your current version of AlpineOS.
 
@@ -45,10 +45,10 @@ sudo apk update
 sudo apk upgrade
 ```
 
-2\) Edit the repository to reflect Alpine v3.15.
+2\) Edit the repository to reflect Alpine v3.16.
 
 ```
-sudo sed -i 's@v3.14@v3.15@g' /etc/apk/repositories
+sudo sed -i 's@v3.15@v3.16@g' /etc/apk/repositories
 ```
 
 3\) Update the package list.
@@ -57,7 +57,7 @@ sudo sed -i 's@v3.14@v3.15@g' /etc/apk/repositories
 sudo apk update
 ```
 
-4\) Upgrading packages to v3.15
+4\) Upgrading packages to v3.16
 
 ```
 sudo apk add --upgrade apk-tools
@@ -75,7 +75,7 @@ sudo sync
 sudo reboot now
 ```
 
-5\) Now you should have AlpineOS upgraded to v3.15 🍷.
+5\) Now you should have AlpineOS upgraded to v3.16 🍷.
 
 ```
 cat /etc/alpine-release
@@ -85,7 +85,7 @@ cat /etc/alpine-release
 
 ## Initial Setup for AlpineOS on Raspberry Pi 4B 8GB:
 
-1\) Download the AlpineOS for RPi 4 aarch64 [here](https://dl-cdn.alpinelinux.org/alpine/v3.15/releases/aarch64/alpine-rpi-3.15.0-aarch64.tar.gz).
+1\) Download the AlpineOS for RPi 4 aarch64 [here](https://dl-cdn.alpinelinux.org/alpine/v3.16/releases/aarch64/alpine-rpi-3.16.0-aarch64.tar.gz).
 
 2\) Decompress the .tar.gz file and copy it's contents into an SSD/SD card
 
@@ -212,7 +212,7 @@ Replace `<tag>` with the latest tag in the next command.
 ## Installing/Upgrading the 'cardano-node' and 'cardano-cli' static binaries (AlpineOS uses static binaries almost exclusively so avoid non-static builds)
 
 {% hint style="info" %}
-**You may obtain the static binaries for version 1.33.0 via this** [**link** ](https://dl-cdn.alpinelinux.org/alpine/v3.15/releases/aarch64/alpine-rpi-3.15.0-aarch64.tar.gz)**thanks to Moritz Angermann, the SPO of ZW3RK pool 🙏**
+**You may obtain the static binaries for version 1.35.0 via this** [**link** ](https://github.com/armada-alliance/cardano-node-binaries/blob/main/static-binaries/1_35_0.zip?raw=true)**thanks to Moritz Angermann, the SPO of ZW3RK pool 🙏**
 {% endhint %}
 
 **Run the following commands to download and install the binaries into the correct directory.**
@@ -220,15 +220,17 @@ Replace `<tag>` with the latest tag in the next command.
 * Download the binaries
 
 ```
-    wget -O ~/aarch64-unknown-linux-musl-cardano-node-1.33.0.zip https://ci.zw3rk.com/build/427926/download/1/aarch64-unknown-linux-musl-cardano-node-1.33.0.zip
+    wget -O ~/aarch64-unknown-linux-musl-cardano-node-1.35.0.zip https://github.com/armada-alliance/cardano-node-binaries/blob/main/static-binaries/1_35_0.zip?raw=true
 ```
 
 * Unzip and install the binaries via the commands
 
 ```
-    unzip -d ~/ aarch64-unknown-linux-musl-cardano-node-1.33.0.zip
+    unzip -d ~/ aarch64-unknown-linux-musl-cardano-node-1.35.0.zip
 
     sudo mv ~/cardano-node/* /usr/local/bin/
+    
+    rm -r ~/cardano-node
 ```
 
 ## Install the Armada Alliance Alpine Linux Cardano node service
@@ -300,7 +302,7 @@ Replace `<tag>` with the latest tag in the next command.
 1\) Download Prometheus and node-exporter into the home directory
 
 ```
-    wget -O ~/prometheus.tar.gz https://github.com/prometheus/prometheus/releases/download/v2.32.1/prometheus-2.32.1.linux-arm64.tar.gz
+    wget -O ~/prometheus.tar.gz https://github.com/prometheus/prometheus/releases/download/v2.36.2/prometheus-2.36.2.linux-arm64.tar.gz
 ```
 
 ```


### PR DESCRIPTION
**Major Updates**
- Upgrade instructions from AlpineOS 3.15 to 3.16 now included. New AlpineOS 3.16 link include for those who are performing a clean install.
- Updated links to static builds of cardano-node/cli version 1.35.0 (necessary for the upcoming Vasil hardfork). Follow the upgrade instructions in "Installing/Upgrading the 'cardano-node' and 'cardano-cli' static binaries" section.
- Updated prometheus version to 2.36.2.